### PR TITLE
Use the latest version of the dynamodb api so we can use DynamoDB Local

### DIFF
--- a/lib/alephant/lookup/lookup_helper.rb
+++ b/lib/alephant/lookup/lookup_helper.rb
@@ -16,7 +16,6 @@ module Alephant
         logger.info "LookupHelper#initialize(#{lookup_table.table_name})"
 
         @lookup_table = lookup_table
-        @lookup_table.create
       end
 
       def read(id, opts, batch_version)
@@ -29,13 +28,11 @@ module Alephant
         logger.info "LookupHelper#write(#{id}, #{opts}, #{batch_version}, #{location})"
 
         LookupLocation.new(id, opts, batch_version, location).tap do |l|
-          lookup_table.table.batch_put([
-            {
-              :component_key => l.component_key,
-              :batch_version => l.batch_version,
-              :location      => l.location
-            }
-          ])
+          lookup_table.write(
+            l.component_key,
+            l.batch_version,
+            l.location
+          )
         end
       end
 

--- a/spec/lookup_spec.rb
+++ b/spec/lookup_spec.rb
@@ -18,7 +18,6 @@ describe Alephant::Lookup do
       it "calls create on lookup_table" do
         table = double()
         table.should_receive(:table_name)
-        table.should_receive(:create)
         subject.new(table, Logger.new(STDOUT))
       end
     end
@@ -73,26 +72,25 @@ describe Alephant::Lookup do
 
     describe "#write(opts, location)" do
       it "does not fail" do
-        AWS::DynamoDB
+
+        AWS::DynamoDB::Client::V20120810
           .any_instance
           .stub(:initialize)
           .and_return(
             double().as_null_object
           )
 
-        ddb_table = double().as_null_object
-        ddb_table
-          .should_receive(:batch_put)
-          .with([{
-            :component_key => "id/7e0c33c476b1089500d5f172102ec03e",
-            :batch_version => "0",
-            :location => "/location"
-          }])
-
         lookup_table = double().as_null_object
         lookup_table
-          .should_receive(:table)
-          .and_return(ddb_table)
+          .should_receive(:table_name)
+          .and_return('test')
+        lookup_table
+          .should_receive(:write)
+          .with(
+            "id/7e0c33c476b1089500d5f172102ec03e",
+            "0",
+            "/location"
+          )
 
         Alephant::Lookup::LookupHelper
           .any_instance


### PR DESCRIPTION
This PR refactors our use of the old client to use the new client and removes the logic for checking if a table exists and creating it as this should be done outside of this gem.
