### PR TITLE
Lookup_helper uses global logger rather than taking one as an constructo...

### DIFF
--- a/lib/alephant/lookup.rb
+++ b/lib/alephant/lookup.rb
@@ -11,7 +11,7 @@ module Alephant
 
     def self.create(table_name)
       @@lookup_tables[table_name] ||= LookupTable.new(table_name)
-      LookupHelper.new(@@lookup_tables[table_name], Logger.get_logger)
+      LookupHelper.new(@@lookup_tables[table_name])
     end
   end
 end

--- a/lib/alephant/lookup/lookup_helper.rb
+++ b/lib/alephant/lookup/lookup_helper.rb
@@ -10,9 +10,7 @@ module Alephant
 
       attr_reader :lookup_table
 
-      def initialize(lookup_table, logger)
-        Logger.set_logger(logger)
-
+      def initialize(lookup_table)
         logger.info "LookupHelper#initialize(#{lookup_table.table_name})"
 
         @lookup_table = lookup_table

--- a/spec/lookup_spec.rb
+++ b/spec/lookup_spec.rb
@@ -18,7 +18,7 @@ describe Alephant::Lookup do
       it "calls create on lookup_table" do
         table = double()
         table.should_receive(:table_name)
-        subject.new(table, Logger.new(STDOUT))
+        subject.new(table)
       end
     end
 
@@ -63,7 +63,7 @@ describe Alephant::Lookup do
         table = double().as_null_object
         table.stub(:table_name).and_return("table_name")
 
-        instance = subject.new(table, Logger.new(STDOUT))
+        instance = subject.new(table)
         lookup = instance.read("id", 0, {:variant => "foo"})
 
         expect(lookup.location).to eq("/location")
@@ -97,7 +97,7 @@ describe Alephant::Lookup do
           .stub(:lookup_table)
           .and_return(lookup_table)
 
-        instance = subject.new(lookup_table, Logger.new(STDOUT))
+        instance = subject.new(lookup_table)
         instance.write("id",{},"0","/location")
       end
     end
@@ -109,7 +109,7 @@ describe Alephant::Lookup do
         table.should_receive(:table_name)
         table.should_receive(:truncate!)
 
-        subject = Alephant::Lookup::LookupHelper.new(table, Logger.new(STDOUT))
+        subject = Alephant::Lookup::LookupHelper.new(table)
         subject.truncate!
       end
     end


### PR DESCRIPTION
...r argument.

The lookup helper constructor was reading the global logger via Logger.get_logger, then setting it again with Logger.set_logger. I have changed it to just use the global logger instead of passing in a logger as an argument.