### PR TITLE
Adjust Lookup Cache TTL

### DIFF
--- a/lib/alephant/lookup/lookup_cache.rb
+++ b/lib/alephant/lookup/lookup_cache.rb
@@ -1,5 +1,5 @@
-require 'dalli-elasticache'
-require 'alephant/logger'
+require "dalli-elasticache"
+require "alephant/logger"
 
 module Alephant
   module Lookup
@@ -8,7 +8,7 @@ module Alephant
 
       attr_reader :config
 
-      DEFAULT_TTL  = 5
+      DEFAULT_TTL  = 2
 
       def initialize(config={})
         @config = config
@@ -46,15 +46,15 @@ module Alephant
       end
 
       def ttl
-        config['elasticache_ttl'] || DEFAULT_TTL
+        config["lookup_elasticache_ttl"] || DEFAULT_TTL
       end
 
       def versioned(key)
-        [key, cache_version].compact.join('_')
+        [key, cache_version].compact.join("_")
       end
 
       def cache_version
-        config['elasticache_cache_version']
+        config["elasticache_cache_version"]
       end
     end
 


### PR DESCRIPTION
Adjust Lookup Cache TTL:
* Make default TTL shorter - now 2 seconds
* Change config variable name, so we can use different cache values for different caches

![](https://media.giphy.com/media/xT9DPB2XqaZhaUY2EE/giphy.gif)