### PR TITLE
Remove dalli-elasticache gem

### DIFF
--- a/alephant-lookup.gemspec
+++ b/alephant-lookup.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "alephant-logger"
   spec.add_runtime_dependency "alephant-support"
 
-  spec.add_runtime_dependency "dalli-elasticache"
+  spec.add_runtime_dependency "dalli"
   spec.add_runtime_dependency "crimp"
 end

--- a/lib/alephant/lookup/lookup_cache.rb
+++ b/lib/alephant/lookup/lookup_cache.rb
@@ -1,4 +1,4 @@
-require "dalli-elasticache"
+require "dalli"
 require "alephant/logger"
 
 module Alephant
@@ -14,8 +14,7 @@ module Alephant
         @config = config
 
         unless config_endpoint.nil?
-          @elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, { :expires_in => ttl })
-          @client ||= @elasticache.client
+          @client ||= ::Dalli::Client.new(config_endpoint, { :expires_in => ttl })
         else
           logger.debug "Alephant::LookupCache::#initialize: No config endpoint, NullClient used"
           logger.metric "NoConfigEndpoint"

--- a/lib/alephant/lookup/version.rb
+++ b/lib/alephant/lookup/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Lookup
-    VERSION = "2.1.0".freeze
+    VERSION = "2.2.0".freeze
   end
 end

--- a/spec/lookup_spec.rb
+++ b/spec/lookup_spec.rb
@@ -31,7 +31,7 @@ describe Alephant::Lookup do
           },
           :key_condition_expression => 'component_key = :component_key AND batch_version = :batch_version',
           :expression_attribute_values => {
-            ':component_key' => 'id/218c835cec343537589dbf1619532e4d',
+            ':component_key' => 'id/7ef6e03f709c7e6b1c87bcf908bc5e0e',
             ':batch_version' => 0 # @TODO: Verify if this is nil as this would be 0
           }
         }
@@ -65,7 +65,7 @@ describe Alephant::Lookup do
         expect_any_instance_of(Dalli::ElastiCache).to receive(:client).and_return(Dalli::Client.new)
 
         expect_any_instance_of(Dalli::Client).to receive(:get)
-          .with("table_name/id/218c835cec343537589dbf1619532e4d/0")
+          .with("table_name/id/7ef6e03f709c7e6b1c87bcf908bc5e0e/0")
           .and_return(lookup_location)
         expect_any_instance_of(Dalli::Client).to_not receive(:set)
 
@@ -94,7 +94,7 @@ describe Alephant::Lookup do
         expect(lookup_table)
           .to receive(:write)
           .with(
-            "id/7e0c33c476b1089500d5f172102ec03e",
+            "id/c1d9f50f86825a1a2302ec2449c17196",
             "0",
             "/location"
           )

--- a/spec/lookup_spec.rb
+++ b/spec/lookup_spec.rb
@@ -37,11 +37,13 @@ describe Alephant::Lookup do
         }
       end
 
-      it "queries DynamoDb and returns a location when not in cache" do
-        expect_any_instance_of(Dalli::ElastiCache).to receive(:client).and_return(Dalli::Client.new)
+      let(:cache_client) { Dalli::Client.new }
 
-        expect_any_instance_of(Dalli::Client).to receive(:get)
-        expect_any_instance_of(Dalli::Client).to receive(:set)
+      it "queries DynamoDb and returns a location when not in cache" do
+        expect(Dalli::Client).to receive(:new).and_return(cache_client)
+
+        expect(cache_client).to receive(:get)
+        expect(cache_client).to receive(:set)
 
         expect_any_instance_of(Aws::DynamoDB::Client)
           .to receive(:query)
@@ -62,12 +64,12 @@ describe Alephant::Lookup do
       it "reads location from the cache when in cache" do
         lookup_location = Alephant::Lookup::LookupLocation.new("id", {:variant => "foo"}, 0, "/location")
 
-        expect_any_instance_of(Dalli::ElastiCache).to receive(:client).and_return(Dalli::Client.new)
+        expect(Dalli::Client).to receive(:new).and_return(cache_client)
 
-        expect_any_instance_of(Dalli::Client).to receive(:get)
+        expect(cache_client).to receive(:get)
           .with("table_name/id/7ef6e03f709c7e6b1c87bcf908bc5e0e/0")
           .and_return(lookup_location)
-        expect_any_instance_of(Dalli::Client).to_not receive(:set)
+        expect(cache_client).to_not receive(:set)
 
         expect_any_instance_of(Aws::DynamoDB::Client).to_not receive(:query)
 


### PR DESCRIPTION
The dalli-elasticache gem has to potential to cause a blocking 60s timeout when trying to auto-discover elasticache endpoints. We are removing this wrapper in favour of simply using the Dalli client directly as the auto-discovery feature is no longer needed and the dalli-elasticache gem is unmaintained.

I have also updated the tests to reflect the new signature provided by the updated version of Crimp